### PR TITLE
Fixed issue with isString implementation in IE11

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -40,7 +40,7 @@ function isObject(object) {
 }
 
 function isString(object) {
-  return toString.call(object) == '[object String]';
+  return typeof object === 'string' || object instanceof String;
 }
 
 function uniqueId() {


### PR DESCRIPTION
When calling "toString.call(object)" with object being a 'string', IE11 is throwing "Invalid calling object".

When you release the version fixing this, please update the handlebars.binding with it as I caught it there.